### PR TITLE
XPath in MARKUP_VALUE

### DIFF
--- a/src/net/vzurczak/main/XmlRegionAnalyzer.java
+++ b/src/net/vzurczak/main/XmlRegionAnalyzer.java
@@ -77,8 +77,8 @@ public class XmlRegionAnalyzer {
 				break;
 			}
 
-			// ">" and "/" can only indicate a mark-up
-			else if( c == '>' || c == '/' ) {
+			// "/" and "/>" can only indicate a mark-up
+			else if( c == '/' && xml.charAt( this.offset+1 ) == '>' || c == '>' ) {
 				if( analyzeMarkup( xml, positions ))
 					continue;
 

--- a/src/net/vzurczak/tests/XmlRegionAnalyzerTests.java
+++ b/src/net/vzurczak/tests/XmlRegionAnalyzerTests.java
@@ -554,6 +554,24 @@ public class XmlRegionAnalyzerTests {
 		Assert.assertEquals( regions.get( 2 ).getXmlRegionType(), XmlRegionType.MARKUP );
 		Assert.assertEquals( regions.get( 2 ).getStart(), 15 );
 		Assert.assertEquals( regions.get( 2 ).getEnd(), sb.length());
+		
+	  // Let's try with something like a XPath
+		sb = new StringBuilder( "<test> /Xpath  </test>" );
+		regions = analyzer.analyzeXml( sb.toString());
+		testRegionsContiguity( regions, sb.toString());
+
+		Assert.assertEquals( regions.size(), 3 );
+		Assert.assertEquals( regions.get( 0 ).getXmlRegionType(), XmlRegionType.MARKUP );
+		Assert.assertEquals( regions.get( 0 ).getStart(), 0 );
+		Assert.assertEquals( regions.get( 0 ).getEnd(), 6 );
+
+		Assert.assertEquals( regions.get( 1 ).getXmlRegionType(), XmlRegionType.MARKUP_VALUE );
+		Assert.assertEquals( regions.get( 1 ).getStart(), 6 );
+		Assert.assertEquals( regions.get( 1 ).getEnd(), 15 );
+
+		Assert.assertEquals( regions.get( 2 ).getXmlRegionType(), XmlRegionType.MARKUP );
+		Assert.assertEquals( regions.get( 2 ).getStart(), 15 );
+		Assert.assertEquals( regions.get( 2 ).getEnd(), sb.length());
 
 
 		// A mix with comments


### PR DESCRIPTION
Hi,

I am using Xml-Region-Analyzer in one of my little project and I had an issue with a MARKUP_VALUE containing a XPath (such as <xml>/root</xml> ).

I fixed this issue for my own purpose. I therefore propose you thsi modification as a pull request. I also amended the JUnit class to include this case.

Thanks again for making this code available!

Regards,
Pierre.
